### PR TITLE
Make signed_params public

### DIFF
--- a/lib/simple_oauth.rb
+++ b/lib/simple_oauth.rb
@@ -66,14 +66,14 @@ module SimpleOAuth
       options.replace(original_options)
       valid
     end
+    
+    def signed_attributes
+      attributes.merge(:oauth_signature => signature)
+    end
 
     private
       def normalized_attributes
         signed_attributes.sort_by{|k,v| k.to_s }.map{|k,v| %(#{k}="#{self.class.encode(v)}") }.join(', ')
-      end
-
-      def signed_attributes
-        attributes.merge(:oauth_signature => signature)
       end
 
       def attributes


### PR DESCRIPTION
I was doing some integration with the yelp api recently and I found the more common OAuth gem to be really painful to do query string based authentication.  Because signed_params wasn't public, I couldn't use SimpleOAuth out of the box to generate the required headers.

This change lets you do something like:  

header = SimpleOAuth::Header.new(:get, "http://api.yelp.com/v2/search", params, keys_hash)
response = Typhoeus::Request.get("http://api.yelp.com/v2/search", :params => params.merge(header.signed_params))
