### PR TITLE
OAuth attributes should include optional OAuth 1.0a keys

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -1,6 +1,6 @@
 module SimpleOAuth
   class Header
-    ATTRIBUTE_KEYS = [:consumer_key, :nonce, :signature_method, :timestamp, :token, :version] unless defined? ::SimpleOAuth::Header::ATTRIBUTE_KEYS
+    ATTRIBUTE_KEYS = [:callback, :consumer_key, :nonce, :signature_method, :timestamp, :token, :verifier, :version] unless defined? ::SimpleOAuth::Header::ATTRIBUTE_KEYS
 
     def self.default_options
       {


### PR DESCRIPTION
Callback is required to obtain access tokens from Twitter, probably others. Verifier may as well be supported.
