### PR TITLE
Add support for optional 'linear white space' between header parameters ...

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -25,7 +25,7 @@ module SimpleOAuth
     end
 
     def self.parse(header)
-      header.to_s.sub(/^OAuth\s/, '').split(', ').inject({}) do |attributes, pair|
+      header.to_s.sub(/^OAuth\s/, '').split(/,[\s\t]*/).inject({}) do |attributes, pair|
         match = pair.match(/^(\w+)\=\"([^\"]*)\"$/)
         attributes.merge(match[1].sub(/^oauth_/, '').to_sym => decode(match[2]))
       end

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -86,6 +86,24 @@ describe SimpleOAuth::Header do
       parsed_options.should have_key(:signature)
       parsed_options[:signature].should_not be_nil
     end
+    
+    it 'should handle optional "linear white space"' do
+      parsed_header_with_spaces = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd", oauth_nonce="oLKtec51GQy", oauth_signature="efgh%26mnop", oauth_signature_method="PLAINTEXT", oauth_timestamp="1286977095", oauth_token="ijkl", oauth_version="1.0"'
+      parsed_header_with_spaces.should be_a_kind_of(Hash)
+      parsed_header_with_spaces.keys.size.should eq 7
+
+      parsed_header_with_tabs = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd", oauth_nonce="oLKtec51GQy",  oauth_signature="efgh%26mnop",  oauth_signature_method="PLAINTEXT", oauth_timestamp="1286977095", oauth_token="ijkl", oauth_version="1.0"'
+      parsed_header_with_tabs.should be_a_kind_of(Hash)
+      parsed_header_with_tabs.keys.size.should eq 7
+
+      parsed_header_with_spaces_and_tabs = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd",  oauth_nonce="oLKtec51GQy",   oauth_signature="efgh%26mnop",   oauth_signature_method="PLAINTEXT",  oauth_timestamp="1286977095",  oauth_token="ijkl",  oauth_version="1.0"'
+      parsed_header_with_spaces_and_tabs.should be_a_kind_of(Hash)
+      parsed_header_with_spaces_and_tabs.keys.size.should eq 7
+
+      parsed_header_without_spaces = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd",oauth_nonce="oLKtec51GQy",oauth_signature="efgh%26mnop",oauth_signature_method="PLAINTEXT",oauth_timestamp="1286977095",oauth_token="ijkl",oauth_version="1.0"'
+      parsed_header_without_spaces.should be_a_kind_of(Hash)
+      parsed_header_without_spaces.keys.size.should eq 7
+    end
   end
 
   describe '#initialize' do


### PR DESCRIPTION
...as per OAuth spec and RFC2617

RFC2234 (http://www.ietf.org/rfc/rfc2234.txt) defines 'linear white space' as the characters "space and horizontal tab." 
