### PR TITLE
Fix regex pattern in Header.parse to remove redundency and simplify

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -25,7 +25,7 @@ module SimpleOAuth
     end
 
     def self.parse(header)
-      header.to_s.sub(/^OAuth\s/, '').split(/,[\s\t]*/).inject({}) do |attributes, pair|
+      header.to_s.sub(/^OAuth\s/, '').split(/,\s*/).inject({}) do |attributes, pair|
         match = pair.match(/^(\w+)\=\"([^\"]*)\"$/)
         attributes.merge(match[1].sub(/^oauth_/, '').to_sym => decode(match[2]))
       end


### PR DESCRIPTION
Pattern now matches a comma followed by an optional, variable amount of whitespace, including carriage returns.
