### PR TITLE
Unionizing attribute keys to add easy support for implementations that require supplemental arguments

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -71,8 +71,12 @@ module SimpleOAuth
       signed_attributes.sort_by{|k,v| k.to_s }.map{|k,v| %(#{k}="#{self.class.encode(v)}") }.join(', ')
     end
 
+    def attribute_keys
+      (ATTRIBUTE_KEYS + options.keys).uniq
+    end
+
     def attributes
-      ATTRIBUTE_KEYS.inject({}){|a,k| options.key?(k) ? a.merge(:"oauth_#{k}" => options[k]) : a }
+      attribute_keys.inject({}){|a,k| options.key?(k) ? a.merge(:"oauth_#{k}" => options[k]) : a }
     end
 
     def signature


### PR DESCRIPTION
Attribute keys are now the union of the keys we must have, and the keys we provided, so that extra keys in the oauth payload are not silently omitted.

In particular, the Twitter API expects a custom Authorization header in at least some of the calls.

This is somewhat similar to Pull Req #6, but they achieve slightly different ends. One favors convention over configuration for a few more of the knobs, the other (this pull) is a little more configuration over convention.
