### PR TITLE
Allow oauth options to have string keys.

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -50,7 +50,15 @@ module SimpleOAuth
       @uri.normalize!
       @uri.fragment = nil
       @params = params
-      @options = oauth.is_a?(Hash) ? self.class.default_options.merge(oauth) : self.class.parse(oauth)
+      @options = oauth.is_a?(Hash) ? self.class.default_options.merge(symbolize_keys(oauth)) : self.class.parse(oauth)
+    end
+
+    def symbolize_keys(options)
+      keys = options.keys
+      keys.each do |key|
+        options[key.to_sym] = options.delete(key)
+      end
+      options
     end
 
     def url

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -194,6 +194,12 @@ describe SimpleOAuth::Header do
       expect(attributes).not_to have_key(:oauth_other)
     end
 
+    it "includes string keys" do
+      SimpleOAuth::Header.new(:get, 'https://api.twitter.com/1/statuses/friendships.json', {}, {"callback" => "CALLBACK"})
+      expect(attributes.keys).to be_all{|k| k.is_a?(Symbol) }
+      expect(attributes).to have_key(:oauth_callback)
+    end
+
     it "preserves values for valid keys" do
       expect(attributes.size).to eq SimpleOAuth::Header::ATTRIBUTE_KEYS.size
       expect(attributes).to be_all{|k,v| k.to_s == "oauth_#{v.downcase}" }


### PR DESCRIPTION
This is useful, for example, when loading consumer_key and consumer_secret from a YAML file, which creates the keys as strings rather than symbols.
