### PR TITLE
don't symbolize arbitrary user-supplied strings

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -6,6 +6,7 @@ require 'cgi'
 module SimpleOAuth
   class Header
     ATTRIBUTE_KEYS = [:callback, :consumer_key, :nonce, :signature_method, :timestamp, :token, :verifier, :version] unless defined? ::SimpleOAuth::Header::ATTRIBUTE_KEYS
+    HEADER_KEYS = ATTRIBUTE_KEYS + [:signature]
     attr_reader :method, :params, :options
 
     class << self
@@ -21,7 +22,10 @@ module SimpleOAuth
       def parse(header)
         header.to_s.sub(/^OAuth\s/, '').split(/,\s*/).inject({}) do |attributes, pair|
           match = pair.match(/^(\w+)\=\"([^\"]*)\"$/)
-          attributes.merge(match[1].sub(/^oauth_/, '').to_sym => unescape(match[2]))
+          key_s = match[1].sub(/^oauth_/, '')
+          # use a symbol only when the parameter is a recognized header key
+          key = HEADER_KEYS.detect { |k| k.to_s == key_s } || key_s
+          attributes.merge(key => unescape(match[2]))
         end
       end
 

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -87,6 +87,14 @@ describe SimpleOAuth::Header do
       expect(parsed_options[:signature]).not_to be_nil
     end
 
+    it "does not symbolize unrecognized input header attributes" do
+      parsed_with_extra = SimpleOAuth::Header.parse(%q(OAuth oauth_foobar="baz", oauth_nonce="thenonce", oauth_signature="signature"))
+      expect(parsed_with_extra).to have_key(:signature)
+      expect(parsed_with_extra).to have_key(:nonce)
+      expect(parsed_with_extra).to have_key(:signature)
+      expect(parsed_with_extra).to have_key('foobar')
+    end
+
     it "handles optional 'linear white space'" do
       parsed_header_with_spaces = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd", oauth_nonce="oLKtec51GQy", oauth_signature="efgh%26mnop", oauth_signature_method="PLAINTEXT", oauth_timestamp="1286977095", oauth_token="ijkl", oauth_version="1.0"'
       expect(parsed_header_with_spaces).to be_a_kind_of(Hash)


### PR DESCRIPTION
the symbolization of arbitrary user-supplied strings is a DoS / memory exhaustion vulnerability. this patch limits the symbols which SimpleOAuth uses for keys in the .parse method to those that are recognized attributes of an oauth authorization header. 

this does create some inconsistency, where some parts of the hash returned from .parse will be strings and others will be symbols, but this seems necessary: the recognized keys must remain symbols to avoid breaking pretty much every application using this library; the unrecognized keys must not be symbols to avoid the vulnerability. 
