### PR TITLE
refactor .parse for robustness

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -22,7 +22,13 @@ module SimpleOAuth
       end
 
       def parse(header)
-        header.to_s.sub(/^OAuth\s/, '').split(/,\s*/).inject({}) do |attributes, pair|
+        header = header.to_s
+        if header =~ /^OAuth\s/
+          header = $'
+        else
+          raise ParseError, "Received non-OAuth header: #{header}"
+        end
+        header.split(/,\s*/).inject({}) do |attributes, pair|
           match = pair.match(/^oauth_(\w+)\=\"([^\"]*)\"$/)
           if match
             key_s = match[1]

--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -27,9 +27,13 @@ module SimpleOAuth
         scanner = StringScanner.new(header)
         scanner.scan(/OAuth\s*/) || raise(ParseError, "Authorization header must begin with 'OAuth ' - recieved: #{header}")
         attributes = {}
-        while match = scanner.scan(/oauth_(\w+)="([^"]*)"\s*,?\s*/)
+        while match = scanner.scan(/oauth_(\w+)="([^"]*)"\s*(,?)\s*/)
           key_s = scanner[1]
           value = scanner[2]
+          comma_follows = !scanner[3].empty?
+          if !comma_follows && !scanner.eos?
+            raise ParseError, "Could not parse Authorization header: #{header}\naround or after character #{scanner.pos}: #{scanner.rest}"
+          end
           # use a symbol only when the parameter is a recognized header key
           key = HEADER_KEYS.detect { |k| k.to_s == key_s } || key_s
           attributes.update(key => unescape(value))

--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -6,6 +6,7 @@ require 'cgi'
 module SimpleOAuth
   class Header
     ATTRIBUTE_KEYS = [:callback, :consumer_key, :nonce, :signature_method, :timestamp, :token, :verifier, :version] unless defined? ::SimpleOAuth::Header::ATTRIBUTE_KEYS
+    HEADER_KEYS = ATTRIBUTE_KEYS + [:signature]
     attr_reader :method, :params, :options
 
     class << self
@@ -21,7 +22,10 @@ module SimpleOAuth
       def parse(header)
         header.to_s.sub(/^OAuth\s/, '').split(/,\s*/).inject({}) do |attributes, pair|
           match = pair.match(/^(\w+)\=\"([^\"]*)\"$/)
-          attributes.merge(match[1].sub(/^oauth_/, '').to_sym => unescape(match[2]))
+          key_s = match[1].sub(/^oauth_/, '')
+          # use a symbol only when the parameter is a recognized header key
+          key = HEADER_KEYS.detect { |k| k.to_s == key_s } || key_s
+          attributes.merge(key => unescape(match[2]))
         end
       end
 

--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -27,16 +27,18 @@ module SimpleOAuth
         scanner = StringScanner.new(header)
         scanner.scan(/OAuth\s*/) || raise(ParseError, "Authorization header must begin with 'OAuth ' - recieved: #{header}")
         attributes = {}
-        while match = scanner.scan(/oauth_(\w+)="([^"]*)"\s*(,?)\s*/)
+        while match = scanner.scan(/(\w+)="([^"]*)"\s*(,?)\s*/)
           key_s = scanner[1]
           value = scanner[2]
           comma_follows = !scanner[3].empty?
           if !comma_follows && !scanner.eos?
             raise ParseError, "Could not parse Authorization header: #{header}\naround or after character #{scanner.pos}: #{scanner.rest}"
           end
-          # use a symbol only when the parameter is a recognized header key
-          key = HEADER_KEYS.detect { |k| k.to_s == key_s } || key_s
-          attributes.update(key => unescape(value))
+          # only return recognized header keys with an oauth_ prefix 
+          key = HEADER_KEYS.detect { |k| "oauth_#{k}" == key_s }
+          if key
+            attributes.update(key => unescape(value))
+          end
         end
         unless scanner.eos?
           raise ParseError, "Could not parse Authorization header: #{header}\naround or after character #{scanner.pos}: #{scanner.rest}"

--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -23,9 +23,9 @@ module SimpleOAuth
 
       def parse(header)
         header.to_s.sub(/^OAuth\s/, '').split(/,\s*/).inject({}) do |attributes, pair|
-          match = pair.match(/^(\w+)\=\"([^\"]*)\"$/)
+          match = pair.match(/^oauth_(\w+)\=\"([^\"]*)\"$/)
           if match
-            key_s = match[1].sub(/^oauth_/, '')
+            key_s = match[1]
             # use a symbol only when the parameter is a recognized header key
             key = HEADER_KEYS.detect { |k| k.to_s == key_s } || key_s
             attributes.merge(key => unescape(match[2]))

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -112,6 +112,10 @@ describe SimpleOAuth::Header do
       expect(parsed_header_without_spaces).to be_a_kind_of(Hash)
       expect(parsed_header_without_spaces.keys.size).to eq 7
     end
+
+    it "raises ParseError on malformed input" do
+      expect { SimpleOAuth::Header.parse(%q(OAuth huh=/)) }.to raise_error(SimpleOAuth::ParseError)
+    end
   end
 
   describe "#initialize" do

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -87,12 +87,12 @@ describe SimpleOAuth::Header do
       expect(parsed_options[:signature]).not_to be_nil
     end
 
-    it "does not symbolize unrecognized input header attributes" do
+    it "does not return unrecognized input header attributes" do
       parsed_with_extra = SimpleOAuth::Header.parse(%q(OAuth oauth_foobar="baz", oauth_nonce="thenonce", oauth_signature="signature"))
       expect(parsed_with_extra).to have_key(:signature)
       expect(parsed_with_extra).to have_key(:nonce)
       expect(parsed_with_extra).to have_key(:signature)
-      expect(parsed_with_extra).to have_key('foobar')
+      expect(parsed_with_extra).not_to have_key('foobar')
     end
 
     it "handles optional 'linear white space'" do
@@ -129,8 +129,9 @@ describe SimpleOAuth::Header do
       expect { SimpleOAuth::Header.parse(%q(OAuth huh=/)) }.to raise_error(SimpleOAuth::ParseError)
     end
 
-    it "raises ParseError on Authorization attributes not prefixed with oauth_" do
-      expect { SimpleOAuth::Header.parse(%q(OAuth foobar="baz")) }.to raise_error(SimpleOAuth::ParseError)
+    it "ignores attributes not prefixed with oauth_" do
+      parsed = SimpleOAuth::Header.parse(%q(OAuth realm="Photos", oauth_consumer_key="dpf43f3p2l4k3l03"))
+      expect(parsed).to eq({:consumer_key => "dpf43f3p2l4k3l03"})
     end
 
     it "raises ParseError when the header does not start with 'OAuth '" do

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -116,6 +116,10 @@ describe SimpleOAuth::Header do
     it "raises ParseError on malformed input" do
       expect { SimpleOAuth::Header.parse(%q(OAuth huh=/)) }.to raise_error(SimpleOAuth::ParseError)
     end
+
+    it "raises ParseError on Authorization attributes not prefixed with oauth_" do
+      expect { SimpleOAuth::Header.parse(%q(OAuth foobar="baz")) }.to raise_error(SimpleOAuth::ParseError)
+    end
   end
 
   describe "#initialize" do

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -120,6 +120,10 @@ describe SimpleOAuth::Header do
     it "raises ParseError on Authorization attributes not prefixed with oauth_" do
       expect { SimpleOAuth::Header.parse(%q(OAuth foobar="baz")) }.to raise_error(SimpleOAuth::ParseError)
     end
+
+    it "raises ParseError when the header does not start with 'OAuth '" do
+      expect { SimpleOAuth::Header.parse(%q(FooAuth foo="baz")) }.to raise_error(SimpleOAuth::ParseError)
+    end
   end
 
   describe "#initialize" do

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -113,6 +113,14 @@ describe SimpleOAuth::Header do
       expect(parsed_header_without_spaces.keys.size).to eq 7
     end
 
+    it "handles commas inside quoted values" do
+      # note that this is invalid according to the spec; commas should be %-encoded, but this is accepted in 
+      # the interests of robustness and consistency (other characters are accepted when they should really be 
+      # escaped). 
+      header_with_commas = 'OAuth oauth_consumer_key="a,bcd", oauth_nonce="o,LKtec51GQy", oauth_signature="efgh%2Cmnop"'
+      expect(SimpleOAuth::Header.parse(header_with_commas)).to eq({:consumer_key => "a,bcd", :nonce => "o,LKtec51GQy", :signature => "efgh,mnop"})
+    end
+
     it "raises ParseError on malformed input" do
       expect { SimpleOAuth::Header.parse(%q(OAuth huh=/)) }.to raise_error(SimpleOAuth::ParseError)
     end

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -87,6 +87,14 @@ describe SimpleOAuth::Header do
       expect(parsed_options[:signature]).not_to be_nil
     end
 
+    it "does not symbolize unrecognized input header attributes" do
+      parsed_with_extra = SimpleOAuth::Header.parse(%q(OAuth oauth_foobar="baz", oauth_nonce="thenonce", oauth_signature="signature"))
+      expect(parsed_with_extra).to have_key(:signature)
+      expect(parsed_with_extra).to have_key(:nonce)
+      expect(parsed_with_extra).to have_key(:signature)
+      expect(parsed_with_extra).to have_key('foobar')
+    end
+
     it "handles optional 'linear white space'" do
       parsed_header_with_spaces = SimpleOAuth::Header.parse 'OAuth oauth_consumer_key="abcd", oauth_nonce="oLKtec51GQy", oauth_signature="efgh%26mnop", oauth_signature_method="PLAINTEXT", oauth_timestamp="1286977095", oauth_token="ijkl", oauth_version="1.0"'
       expect(parsed_header_with_spaces).to be_a_kind_of(Hash)

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -121,6 +121,10 @@ describe SimpleOAuth::Header do
       expect(SimpleOAuth::Header.parse(header_with_commas)).to eq({:consumer_key => "a,bcd", :nonce => "o,LKtec51GQy", :signature => "efgh,mnop"})
     end
 
+    it "raises ParseError on input without a comma between key/value pairs" do
+      expect { SimpleOAuth::Header.parse(%q(OAuth oauth_consumer_key="k" oauth_nonce="n")) }.to raise_error(SimpleOAuth::ParseError)
+    end
+
     it "raises ParseError on malformed input" do
       expect { SimpleOAuth::Header.parse(%q(OAuth huh=/)) }.to raise_error(SimpleOAuth::ParseError)
     end


### PR DESCRIPTION
following #13 I have noticed a couple other issues, all of which I've fixed by refactoring `.parse`. 
- a badly formed Authorization header results in the rather unuseful error `NoMethodError: undefined method '[]' for nil:NilClass`. I've reworked things to raise a SimpleOauth::ParseError with a relatively informative message. 
- while other characters may be passed in without proper escaping (despite this not being strictly valid per the OAuth spec), commas passed in unescaped break the parsing. I've changed to allow unescaped commas the same as any other character. this necessitated a change to use a StringScanner rather than simply splitting, which I think makes the whole thing more robust. 
- Authorization header params prefixed with `oauth_` are treated the same as those without the `oauth_` prefix. I check that all params are properly prefixed with `oauth_` and silently ignore them if they are not recognized parameters starting with `oauth_` ~~raise ParseError if not~~ [changed]. 
