### PR TITLE
add support for oauth params in a post body

### DIFF
--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -80,7 +80,7 @@ module SimpleOAuth
       params.inject([{}, {}]) do |ret_array, (k, v)|
         option_key = k.to_s
         option_key = option_key.sub('oauth_', '').to_sym if option_key.start_with?('oauth_')
-        if SimpleOAuth::Header::ATTRIBUTE_KEYS.include?(option_key)
+        if SimpleOAuth::Header::ATTRIBUTE_KEYS.include?(option_key) || option_key == :signature
           ret_array[0][option_key] = v
         else
           ret_array[1][k] = v

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -122,7 +122,7 @@ describe SimpleOAuth::Header do
     end
 
     it 'sorts valid oauth params into options' do
-      params = {'oauth_nonce' => 'nonce', oauth_signature_method: 'special', timestamp: '123456', oauth_callback: 'callback', 'oauth_wrong' => 'a param'}
+      params = {'oauth_nonce' => 'nonce', oauth_signature_method: 'special', timestamp: '123456', oauth_callback: 'callback', oauth_signature: 'signature', 'oauth_wrong' => 'a param'}
       header = SimpleOAuth::Header.new(:get, 'HTTPS://api.TWITTER.com:443/1/statuses/friendships.json?foo=bar#anchor', params)
 
       expect(header.params.size).to eq 2
@@ -132,6 +132,7 @@ describe SimpleOAuth::Header do
       expect(header.options[:nonce]).to eq 'nonce'
       expect(header.options[:signature_method]).to eq 'special'
       expect(header.options[:callback]).to eq 'callback'
+      expect(header.options[:signature]).to eq 'signature'
     end
   end
 

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -120,6 +120,19 @@ describe SimpleOAuth::Header do
     it 'ignores the query and fragment' do
       expect(header.url).to match %r{/1/statuses/friendships\.json$}
     end
+
+    it 'sorts valid oauth params into options' do
+      params = {'oauth_nonce' => 'nonce', oauth_signature_method: 'special', timestamp: '123456', oauth_callback: 'callback', 'oauth_wrong' => 'a param'}
+      header = SimpleOAuth::Header.new(:get, 'HTTPS://api.TWITTER.com:443/1/statuses/friendships.json?foo=bar#anchor', params)
+
+      expect(header.params.size).to eq 2
+      expect(header.params[:timestamp]).to eq('123456')
+      expect(header.params['oauth_wrong']).to eq('a param')
+
+      expect(header.options[:nonce]).to eq 'nonce'
+      expect(header.options[:signature_method]).to eq 'special'
+      expect(header.options[:callback]).to eq 'callback'
+    end
   end
 
   describe '#valid?' do


### PR DESCRIPTION
Separate oauth style params from the params hash and
inserts them into the options hash.  This allows for validation
of signatures that use the 'application/x-www-form-urlencoded'
content-type.
