### PR TITLE
Fix warning and deprecation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,12 @@
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Metrics/AbcSize:
   Max: 16
 
@@ -16,9 +25,6 @@ Metrics/ParameterLists:
   Max: 4
   CountKeywordArgs: true
 
-Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
 Style/CollectionMethods:
   PreferredMethods:
     map:      'collect'
@@ -28,9 +34,6 @@ Style/CollectionMethods:
 
 Style/Documentation:
   Enabled: false
-
-Style/DotPosition:
-  EnforcedStyle: trailing
 
 Style/DoubleNegation:
   Enabled: false
@@ -50,8 +53,5 @@ Style/Lambda:
 Style/RaiseArgs:
   EnforcedStyle: compact
 
-Style/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
-Style/TrailingComma:
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,7 +6,7 @@ if RUBY_VERSION >= '1.9'
     [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
   SimpleCov.start do
     add_filter '/spec/'
-    add_filter '.bundle'
+    add_filter '/.bundle/'
     minimum_coverage(100)
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -2,10 +2,11 @@ if RUBY_VERSION >= '1.9'
   require 'simplecov'
   require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
-
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new \
+    [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
   SimpleCov.start do
     add_filter '/spec/'
+    add_filter '.bundle'
     minimum_coverage(100)
   end
 end

--- a/spec/simple_oauth/header_spec.rb
+++ b/spec/simple_oauth/header_spec.rb
@@ -138,7 +138,10 @@ describe SimpleOAuth::Header do
         secrets = {:consumer_secret => rsa_private_key}
         header = SimpleOAuth::Header.new(:get, 'https://api.twitter.com/1/statuses/friends.json', {}, secrets.merge(:signature_method => 'RSA-SHA1'))
         parsed_header = SimpleOAuth::Header.new(:get, 'https://api.twitter.com/1/statuses/friends.json', {}, header)
-        expect { parsed_header.valid? }.to raise_error
+        
+        expect do 
+          parsed_header.valid?
+        end.to raise_error(TypeError)
         expect(parsed_header).to be_valid(secrets)
       end
     end


### PR DESCRIPTION
Fix the following warning and deprecation:

```
spec/helper.rb:5:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.

WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<TypeError: no implicit conversion of nil into String>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /simple_oauth/spec/simple_oauth/header_spec.rb:141:in `block (4 levels) in <top (required)>'.
```