### PR TITLE
Fix warnings in Ruby 3.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 require:
  - standard
+
+plugins:
  - standard-performance
  - rubocop-rspec
  - rubocop-performance
@@ -53,7 +55,10 @@ RSpec/MessageSpies:
 RSpec/PendingWithoutReason:
   Enabled: false
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
   Enabled: false
 
 Style/Alias:

--- a/lib/simple_oauth/header.rb
+++ b/lib/simple_oauth/header.rb
@@ -42,7 +42,7 @@ module SimpleOAuth
       private
 
       def uri_parser
-        @uri_parser ||= URI.const_defined?(:Parser) ? URI::DEFAULT_PARSER : URI
+        @uri_parser ||= URI.const_defined?(:Parser) ? URI::RFC2396_PARSER : URI
       end
     end
 
@@ -89,7 +89,7 @@ module SimpleOAuth
       extra_keys -= IGNORED_KEYS
       raise "SimpleOAuth: Found extra option keys not matching ATTRIBUTE_KEYS:\n  [#{extra_keys.collect(&:inspect).join(", ")}]" unless options[:ignore_extra_keys] || extra_keys.empty?
 
-      options.select { |key, _| matching_keys.include?(key) }.transform_keys { |key| :"oauth_#{key}" }
+      options.slice(*matching_keys).transform_keys { |key| :"oauth_#{key}" }
     end
 
     def signature

--- a/lib/simple_oauth/version.rb
+++ b/lib/simple_oauth/version.rb
@@ -1,3 +1,3 @@
 module SimpleOauth
-  VERSION = "0.1.0".freeze
+  VERSION = "0.3.1".freeze
 end

--- a/simple_oauth.gemspec
+++ b/simple_oauth.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_dependency "base64"
 end


### PR DESCRIPTION
- Update RuboCop config to use plugins instead of require for extensions

- Replace deprecated RSpec/FilePath with RSpec/SpecFilePathFormat and RSpec/SpecFilePathSuffix

- Fix URI parser deprecation by using URI::RFC2396_PARSER instead of URI::DEFAULT_PARSER

- Replace Hash#select with Hash#slice for better performance and clarity

- Add base64 dependency to gemspec for Ruby 3.4 compatibility